### PR TITLE
chore: add conventional commit setup

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,23 @@
+name: Conventional commits
+
+on: pull_request
+
+jobs:
+  check-messages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # we need all the history to be able to resolve revision ranges properly
+          fetch-depth: 0
+      - name: Install commitizen
+        run: python -m pip install commitizen
+      - name: Run commit message checks
+        run: |
+          cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ clean = [
   "make -C docs clean",
 ]
 
+[tool.hatch.envs.cz]
+extra-dependencies = [
+  "commitizen",
+]
+[tool.hatch.envs.cz.scripts]
+check = [
+  # check all commit messages since the (before) beginning
+  "cz check --rev-range 4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD",
+]
 
 [tool.coverage.run]
 source_pkgs = ["datalad_core", "tests"]
@@ -91,4 +100,14 @@ exclude_lines = [
   "if TYPE_CHECKING:",
   "raise NotImplementedError",
 ]
+
+
+[tool.commitizen]
+name = "cz_customize"
+
+[tool.commitizen.customize]
+commit_parser = "^((?P<change_type>feat|fix|rf|perf|test|doc|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?(?P<body>.*)?"
+change_type_order = ["BREAKING CHANGE", "feat", "fix", "rf", "perf", "doc", "test"]
+schema_pattern = "(?s)(ci|doc|feat|fix|perf|rf|style|test|chore|revert|bump)(\\(\\S+\\))?!?:( [^\\n\\r]+)((\\n\\n.*)|(\\s*))?$"
+
 


### PR DESCRIPTION
This includes a GitHub workflow to check PR commit messages, and also a local hatch environment to check all messages via

```
hatch run cz:check
```