### PR TITLE
ci: add workflow and setup to ensure compliance with ruff-enforced style

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,17 @@
+name: Static code check
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          # run on a "fresh" python
+          python-version: 3.12
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install hatch
+        run: python -m pip install hatch
+      - name: Check code
+        run: hatch fmt --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,28 @@ exclude_lines = [
   "raise NotImplementedError",
 ]
 
+[tool.ruff]
+exclude = [
+  # sphinx
+  "docs",
+]
+line-length = 88
+indent-width = 4
+target-version = "py39"
+[tool.ruff.format]
+# Prefer single quotes over double quotes.
+quote-style = "single"
+[tool.ruff.lint.per-file-ignores]
+"**/test_*" = [
+  # permit assert statements in tests
+  "S101",
+  # permit relative import in tests
+  "TID252",
+  # permit versatile function names in tests
+  "N802",
+]
+# permit relative import in subpackage root
+"datalad_core/*/__init__.py" = ["TID252"]
 
 [tool.commitizen]
 name = "cz_customize"


### PR DESCRIPTION
The idea being that we let a machine decide how code needs to look like, and we tell the machine how we like that via configuration.

The configuration is in `pyproject.toml` (`tools.ruff`).

Hatch users can also run

```
hatch fmt [--check]
```