### PR TITLE
chore: versioning and changelog generation setup

### DIFF
--- a/.changelog.md.j2
+++ b/.changelog.md.j2
@@ -1,0 +1,30 @@
+{% for entry in tree %}
+
+# {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+## {{ change_key }}
+{% endif %}
+{% set scopemap = {
+  'changelog': 'Changelog',
+  'contributing': 'Contributing guide',
+  'helpers': 'Helpers',
+  'sphinx': 'Rendered documentation',
+  'typeannotation': 'Type annotation',
+} %}
+
+{# no-scope changes #}
+{% for change in changes | rejectattr("scope") %}
+- {{ change.message }} [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-core/commit/{{ change.sha1 | truncate(8, true, '') }})
+{% endfor %}
+{# scoped changes #}
+{% for scope, scope_changes in changes | selectattr("scope") | groupby("scope") %}
+- {{ scopemap.get(scope, scope) }}:
+{% for change in scope_changes %}
+  - {{ change.message }} [[{{ change.sha1 | truncate(8, true, '') }}]](https://github.com/datalad/datalad-core/commit/{{ change.sha1 | truncate(8, true, '') }})
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# v0.0.0
+
+- Initial package setup without any functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,14 @@ check = [
   # check all commit messages since the (before) beginning
   "cz check --rev-range 4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD",
 ]
+show-changelog = [
+  # show the would-be changelog on stdout
+  "cz changelog --dry-run",
+]
+bump-version = [
+  # bump version (also tags) and update changelog
+  "cz bump --changelog",
+]
 
 [tool.coverage.run]
 source_pkgs = ["datalad_core", "tests"]


### PR DESCRIPTION
This is a commitizen-based setup.

Two commands are provided for hatch users (and documented for others) in `pyproject.toml`:

- `cz:show-changelog`
- `cz:bump-version`

Both are (also) concerned with changelog generation. The changelog style is, in principle, similar to other setups we have. However, no pointers to PRs are included.

This is done, because adding critical information to any PR that is only available at a specific service, and is not part of the code base, is **strongly** discourages. All relevant information should be in the sources, all relevant meta-information should be in commit messages.

Consequently, changelog pointers are pointers to commits.

For convenience, GitHub commit page links are included nevertheless. Such links are be easily replaced in bulk when migrating services.