### PR TITLE
chore: dynamic version setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+datalad_core/_version.py
 dist/
 .coverage
 docs/generated

--- a/datalad_core/__init__.py
+++ b/datalad_core/__init__.py
@@ -1,1 +1,7 @@
 from __future__ import annotations
+
+from datalad_core._version import __version__
+
+__all__ = [
+    '__version__',
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ Changelog = "https://github.com/datalad/datalad-core/blob/main/CHANGELOG.md"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "datalad_core/_version.py"
+
 [tool.hatch.envs.hatch-test]
 default-args = ["datalad_core"]
 extra-dependencies = [


### PR DESCRIPTION
This is using a hatch build hook. The version is written to `datalad_core._version.py` whenever the package is built/installed.