### PR TITLE
Add pre-commit configuration (with codespell etc) to ensure no typos and more consistent formatting etc 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@
 #     respective CI run configuration).
 
 
-# do not make repository clone cheap: interfers with VCS-based version determination
+# do not make repository clone cheap: interferes with VCS-based version determination
 shallow_clone: false
 
 # turn of support for MS project build support (not needed)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+exclude: versioneer.py|\.all-contributorsrc|\.tributors
+repos:
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+    -   id: codespell
+        exclude: datalad/tests/ca/certificate-key.pem

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: versioneer.py|\.all-contributorsrc|\.tributors
 repos:
 -   repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:
-    -   id: isort
+    - id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-symlinks
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.0.0
     hooks:
-    -   id: codespell
-        exclude: datalad/tests/ca/certificate-key.pem
+    - id: codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,11 @@ check = "codespell"
 fix = "codespell --write-changes"
 
 [tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = ".git,build,.*cache,dist"
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''
 
 [tool.coverage.run]
 source_pkgs = ["datalad_core", "tests"]


### PR DESCRIPTION
Relates to development procedures (hence #10)

TODOs if we agree to proceed

- [ ] replace isort with `hatch fmt` or direct invocation to ruff? see  https://github.com/pypa/hatch/issues/1223
- [ ] CI run to invoke pre-commit
  - cons in comparison to dedicated codespell action is that I do not think we would get annotations as we would get with using codespell-project/codespell-problem-matcher .  So for codespell we could even have a dedicated CI run if no objections 

may be

- use `black`? (yet to compare to `hatch fmt`)