### PR TITLE
ci: add locally runable codespell setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,17 @@ bump-version = [
   "cz bump --changelog",
 ]
 
+[tool.hatch.envs.codespell]
+extra-dependencies = [
+  "codespell",
+]
+[tool.hatch.envs.codespell.scripts]
+check = "codespell"
+fix = "codespell --write-changes"
+
+[tool.codespell]
+skip = ".git,build,.*cache,dist"
+
 [tool.coverage.run]
 source_pkgs = ["datalad_core", "tests"]
 branch = true


### PR DESCRIPTION
An alternative for CI integration has be proposed (see refs). This adds the necessary setup to configure and run this locally.

Two commands are provided (both discoverable via `hatch env show`:

- `codespell:check` (what would be executed by a CI)
- `codespell:fix` (to apply suggested fixes to the sources)

Refs: https://github.com/datalad/datalad-core/pull/11