### PR TITLE
chore: elevate hatch environment setups and description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,19 @@ extra-dependencies = [
   "pytest-cov",
 ]
 
+
+[tool.hatch.envs.tests]
+description = "run tests across Python versions"
+template = "hatch-test"
+
+[[tool.hatch.envs.tests.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12"]
+
+[tool.hatch.envs.tests.scripts]
+run = 'python -m pytest'
+
 [tool.hatch.envs.types]
+description = "type checking with MyPy"
 extra-dependencies = [
   "mypy>=1.0.0",
   "pytest",
@@ -71,6 +83,7 @@ check = [
 ]
 
 [tool.hatch.envs.docs]
+description = "build Sphinx-based docs"
 extra-dependencies = [
   "sphinx",
 ]
@@ -84,11 +97,13 @@ clean = [
 ]
 
 [tool.hatch.envs.cz]
+description = "commit compliance, changelog, and release generation"
+detached = true
 extra-dependencies = [
   "commitizen",
 ]
 [tool.hatch.envs.cz.scripts]
-check = [
+check-commits = [
   # check all commit messages since the (before) beginning
   "cz check --rev-range 4b825dc642cb6eb9a060e54bf8d69288fbee4904..HEAD",
 ]
@@ -102,6 +117,8 @@ bump-version = [
 ]
 
 [tool.hatch.envs.codespell]
+description = "spell checking"
+detached = true
 extra-dependencies = [
   "codespell",
 ]


### PR DESCRIPTION
There is now a setup for matrix test runs across Python versions.

All environments now also come with self descriptions that are shown with `hatch env show`.

Environments that do not need an installed package for their function now no longer do that.