### PR TITLE
feat: dedicated `ConstraintError` for structured reporting on validation errors

### DIFF
--- a/datalad_core/constraints/__init__.py
+++ b/datalad_core/constraints/__init__.py
@@ -1,0 +1,23 @@
+"""Parameter validation, coercion, and documentation
+
+For (validation/coercion) errors, a :class:`ConstraintError` class is provided.
+This class supports error reporting in a structure fashion with standard (yet
+customizable) error messages, and is capable of communicating the underlying
+causes of an error in full detail without the need to generate long textual
+descriptions.
+
+.. currentmodule:: datalad_core.constraints
+.. autosummary::
+   :toctree: generated
+
+   ConstraintError
+"""
+
+__all__ = [
+    'ConstraintError',
+]
+
+
+from .exceptions import (
+    ConstraintError,
+)

--- a/datalad_core/constraints/__init__.py
+++ b/datalad_core/constraints/__init__.py
@@ -1,5 +1,21 @@
 """Parameter validation, coercion, and documentation
 
+This module provides a set of classes to validate and document
+parameters. In a nutshell, each of these
+:class:`Constraint` classes:
+
+- focuses on a specific aspect, such as type coercion,
+  or checking particular input properties
+- is instantiated with a set of parameters to customize
+  such an instance for a particular task
+- performs its task by receiving an input via its ``__call__()``
+  method
+- provides default auto-documentation
+
+Individual :class:`Constraint` instances can be combined with logical ``and``
+(:class:`AllOf`) and ``or`` (:class:`AnyOf`) operations to form arbitrarily
+complex constructs.
+
 For (validation/coercion) errors, a :class:`ConstraintError` class is provided.
 This class supports error reporting in a structure fashion with standard (yet
 customizable) error messages, and is capable of communicating the underlying
@@ -10,14 +26,25 @@ descriptions.
 .. autosummary::
    :toctree: generated
 
+   Constraint
+   AllOf
+   AnyOf
    ConstraintError
 """
 
 __all__ = [
+    'Constraint',
+    'AllOf',
+    'AnyOf',
     'ConstraintError',
 ]
 
 
+from .constraint import (
+    AllOf,
+    AnyOf,
+    Constraint,
+)
 from .exceptions import (
     ConstraintError,
 )

--- a/datalad_core/constraints/__init__.py
+++ b/datalad_core/constraints/__init__.py
@@ -22,6 +22,14 @@ customizable) error messages, and is capable of communicating the underlying
 causes of an error in full detail without the need to generate long textual
 descriptions.
 
+If the provided input descriptions and error messages of a particular
+constraint are not an optimal fit for a particular context, they can be replace
+by wrapping a constraint instance into :class:`WithDescription`. This creates a
+new constraint instance that maintains the exact same validation/coercion
+behavior, but has a targeted description (input synopsis and description,
+and/or error message template).
+
+
 .. currentmodule:: datalad_core.constraints
 .. autosummary::
    :toctree: generated
@@ -30,6 +38,7 @@ descriptions.
    AllOf
    AnyOf
    ConstraintError
+   WithDescription
 """
 
 __all__ = [
@@ -37,6 +46,7 @@ __all__ = [
     'AllOf',
     'AnyOf',
     'ConstraintError',
+    'WithDescription',
 ]
 
 
@@ -48,3 +58,4 @@ from .constraint import (
 from .exceptions import (
     ConstraintError,
 )
+from .wrapper import WithDescription

--- a/datalad_core/constraints/constraint.py
+++ b/datalad_core/constraints/constraint.py
@@ -1,0 +1,202 @@
+"""Base classes for constraints and their logical connectives"""
+
+from __future__ import annotations
+
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import Any
+
+from datalad_core.constraints.exceptions import ConstraintError
+
+
+class Constraint(ABC):
+    """Base class for value coercion/validation.
+
+    These classes are also meant to be able to generate appropriate
+    documentation on an appropriate parameter value.
+    """
+
+    def __str__(self) -> str:
+        """Rudimentary self-description"""
+        return f'Constraint[{self.input_synopsis}]'
+
+    def __repr__(self) -> str:
+        """Rudimentary repr to avoid default scary to the user Python repr"""
+        return f'{self.__class__.__name__}()'
+
+    def raise_for(self, value: Any, msg: str, **ctx: Any) -> None:
+        """Convenience method for raising a ``ConstraintError``
+
+        The parameters are identical to those of ``ConstraintError``. This
+        method merely passes the ``Constraint`` instance as ``self`` to the
+        constructor.
+        """
+        if ctx:
+            raise ConstraintError(self, value, msg, ctx)
+        raise ConstraintError(self, value, msg)
+
+    def __and__(self, other: Constraint) -> Constraint:
+        return AllOf(self, other)
+
+    def __or__(self, other: Constraint) -> Constraint:
+        return AnyOf(self, other)
+
+    @property
+    @abstractmethod
+    def input_synopsis(self) -> str:
+        """Returns brief, single line summary of valid input for a constraint
+
+        This information is user-facing, and to be used in any place where
+        space is limited (tooltips, usage summaries, etc).
+
+        If possible, the synopsis should be written in a UI/API-agnostic
+        fashion. However, if this is impossible or leads to imprecisions or
+        confusion, it should focus on use within Python code and with Python
+        data types. Tailored documentation can be provided via the
+        ``WithDescription`` wrapper.
+        """
+
+    @property
+    @abstractmethod
+    def input_description(self) -> str:
+        """Returns full description of valid input for a constraint
+
+        Like ``input_synopsis`` this information is user-facing. In contrast,
+        to the synopsis there is length/line limit. Nevertheless, the
+        information should be presented in a compact fashion that avoids
+        needless verbosity. If possible, a single paragraph is a good format.
+        If multiple paragraphs are necessary, they should be separated by
+        a single, empty line.
+
+        Rendering code may indent, or rewrap the text, so no line-by-line
+        formatting will be preserved.
+
+        If possible, the synopsis should be written in a UI/API-agnostic
+        fashion. However, if this is impossible or leads to imprecisions or
+        confusion, it should focus on use within Python code and with Python
+        data types. Tailored documentation can be provided via the
+        ``WithDescription`` wrapper.
+        """
+
+    # TODO: also have these for AnyOf and AllOf
+    #    def for_dataset(self, dataset: DatasetParameter) -> Constraint:
+    #        """Return a constraint-variant for a specific dataset context
+    #
+    #        The default implementation returns the unmodified, identical
+    #        constraint. However, subclasses can implement different behaviors.
+    #        """
+    #        return self
+
+    @abstractmethod
+    def __call__(self, value: Any):
+        """ """
+        # do any necessary checks or conversions, potentially catch exceptions
+        # and generate a meaningful error message
+
+
+class _MultiConstraint(Constraint):
+    """Helper class to override the description methods to reported
+    multiple constraints
+    """
+
+    def __init__(self, *constraints: Constraint):
+        self._constraints = constraints
+
+    def __repr__(self) -> str:
+        creprs = ', '.join(f'{c!r}' for c in self.constraints)
+        return f'{self.__class__.__name__}({creprs})'
+
+    @property
+    def constraints(self) -> tuple[Constraint, ...]:
+        return self._constraints
+
+    def _get_description(self, attr: str, operation: str) -> str:
+        cs = [getattr(c, attr) for c in self.constraints if hasattr(c, attr)]
+        cs = [c for c in cs if c is not None]
+        doc = f' {operation} '.join(cs)
+        if len(cs) > 1:
+            return f'{doc}'
+        # dont fiddle with the single item, just take it
+        return doc
+
+
+class AnyOf(_MultiConstraint):
+    """Logical OR for constraints.
+
+    An arbitrary number of constraints can be given. They are evaluated in the
+    order in which they were specified. The value returned by the first
+    constraint that does not raise an exception is the global return value.
+
+    Documentation is aggregated for all alternative constraints.
+    """
+
+    def __or__(self, other: Constraint) -> Constraint:
+        constraints = list(self.constraints)
+        if isinstance(other, AnyOf):
+            constraints.extend(other.constraints)
+        else:
+            constraints.append(other)
+        return AnyOf(*constraints)
+
+    def __call__(self, value: Any) -> Any:
+        e_list = []
+        for c in self.constraints:
+            try:
+                return c(value)
+            except Exception as e:  # noqa: BLE001
+                e_list.append(e)
+        self.raise_for(  # noqa: RET503
+            value,
+            # plural OK, no sense in having 1 "alternative"
+            'does not match any of {n_alternatives} alternatives\n'
+            '{__itemized_causes__}',
+            # if any exception would be a ConstraintError
+            # this would not be needed, because they
+            # know the underlying constraint
+            constraints=self.constraints,
+            n_alternatives=len(self.constraints),
+            __caused_by__=e_list,
+        )
+
+    @property
+    def input_synopsis(self) -> str:
+        return self._get_description('input_synopsis', 'or')
+
+    @property
+    def input_description(self) -> str:
+        return self._get_description('input_description', 'or')
+
+
+class AllOf(_MultiConstraint):
+    """Logical AND for constraints.
+
+    An arbitrary number of constraints can be given. They are evaluated in the
+    order in which they were specified. The return value of each constraint is
+    passed an input into the next. The return value of the last constraint
+    is the global return value. No intermediate exceptions are caught.
+
+    Documentation is aggregated for all constraints.
+    """
+
+    def __and__(self, other: Constraint) -> Constraint:
+        constraints = list(self.constraints)
+        if isinstance(other, AllOf):
+            constraints.extend(other.constraints)
+        else:
+            constraints.append(other)
+        return AllOf(*constraints)
+
+    def __call__(self, value: Any) -> Any:
+        for c in self.constraints:
+            value = c(value)
+        return value
+
+    @property
+    def input_synopsis(self) -> str:
+        return self._get_description('input_synopsis', 'and')
+
+    @property
+    def input_description(self) -> str:
+        return self._get_description('input_description', 'and')

--- a/datalad_core/constraints/exceptions.py
+++ b/datalad_core/constraints/exceptions.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from textwrap import indent
+from types import MappingProxyType
+from typing import (
+    Any,
+)
+
+
+class ConstraintError(ValueError):
+    # we derive from ValueError, because it provides the seemingly best fit
+    # of any built-in exception. It is defined as:
+    #
+    #   Raised when an operation or function receives an argument that has
+    #   the right type but an inappropriate value, and the situation is not
+    #   described by a more precise exception such as IndexError.
+    #
+    # In general a validation error can also occur because of a TypeError, but
+    # ultimately what also matters here is an ability to coerce a given value
+    # to a target type/value, but such an exception is not among the built-ins.
+    # Moreover, many pieces of existing code do raise ValueError in practice,
+    # and we aim to be widely applicable with this specialized class
+    """Exception type raised by constraints when their conditions are violated
+
+    A primary purpose of this class is to provide uniform means for
+    communicating structured information on violated constraints.
+
+    """
+
+    def __init__(
+        self,
+        constraint,
+        value: Any,
+        msg: str,
+        ctx: dict[str, Any] | None = None,
+    ):
+        """
+        Parameters
+        ----------
+        constraint: Constraint
+          Instance of the ``Constraint`` class that determined a violation.
+        value:
+          The value that is in violation of a constraint.
+        msg: str
+          A message describing the violation. If ``ctx`` is given too, the
+          message can contain keyword placeholders in Python's ``format()``
+          syntax that will be applied on-access.
+        ctx: dict, optional
+          Mapping with context information on the violation. This information
+          is used to interpolate a message, but may also contain additional
+          key-value mappings. A recognized key is ``'__caused_by__'``, with
+          a value of one exception (or a tuple of exceptions) that led to a
+          ``ConstraintError`` being raised.
+        """
+        # the msg/ctx setup is inspired by pydantic
+        # we put `msg` in the `.args` container first to match where
+        # `ValueError` would have it. Everything else goes after it.
+        super().__init__(msg, constraint, value, ctx)
+
+    @property
+    def msg(self):
+        """Obtain an (interpolated) message on the constraint violation
+
+        The error message template can be interpolated with any information
+        available in the error context dict (``ctx``). In addition to the
+        information provided by the ``Constraint`` that raised the error,
+        the following additional placeholders are provided:
+
+        - ``__value__``: the value reported to have caused the error
+        - ``__itemized_causes__``: an indented bullet list str with on
+          item for each error in the ``caused_by`` report of the error.
+
+        Message template can use any feature of the Python format mini
+        language. For example ``{__value__!r}`` to get a ``repr()``-style
+        representation of the offending value.
+        """
+        msg_tmpl = self.args[0]
+        # get interpolation values for message formatting
+        # we need a copy, because we need to mutate the dict
+        ctx = dict(self.context)
+        # support a few standard placeholders
+        # the verbatim value that caused the error: with !r and !s both
+        # types of stringifications are accessible
+        ctx['__value__'] = self.value
+        if self.caused_by:
+            ctx['__itemized_causes__'] = indent(
+                '\n'.join(f'- {c!s}' for c in self.caused_by),
+                '  ',
+            )
+        return msg_tmpl.format(**ctx)
+
+    @property
+    def constraint(self):
+        """Get the instance of the constraint that was violated"""
+        return self.args[1]
+
+    @property
+    def caused_by(self) -> tuple[Exception] | None:
+        """Returns a tuple of any underlying exceptions"""
+        cb = self.context.get('__caused_by__', None)
+        if cb is None:
+            return None
+        if isinstance(cb, Exception):
+            return (cb,)
+        return tuple(cb)
+
+    @property
+    def value(self):
+        """Get the value that violated the constraint"""
+        return self.args[2]
+
+    @property
+    def context(self) -> MappingProxyType:
+        """Get a constraint violation's context
+
+        This is a mapping of key/value-pairs matching the ``ctx`` constructor
+        argument.
+        """
+        return MappingProxyType(self.args[3] or {})
+
+    def __str__(self) -> str:
+        return self.msg
+
+    def __repr__(self) -> str:
+        # rematch constructor arg-order, because we put `msg` first into
+        # `.args`
+        return '{0}({2!r}, {3!r}, {1!r}, {4!r})'.format(
+            self.__class__.__name__,
+            *self.args,
+        )

--- a/datalad_core/constraints/tests/test_constraint.py
+++ b/datalad_core/constraints/tests/test_constraint.py
@@ -1,0 +1,109 @@
+import pytest
+
+from datalad_core.constraints.constraint import (
+    AllOf,
+    Constraint,
+)
+from datalad_core.constraints.exceptions import ConstraintError
+
+
+class IsTrue(Constraint):
+    input_synopsis = 'must be `True`'
+    input_description = 'long-form of saying: it must be `True`'
+
+    def __call__(self, value):
+        if value is not True:
+            self.raise_for(value, '{__value__} is not True')
+        return True
+
+
+class Equals5(Constraint):
+    input_synopsis = 'must be `5`'
+    input_description = 'long-form of saying: it must be `5`'
+
+    def __call__(self, value):
+        if value != 5:  # noqa: PLR2004
+            self.raise_for(value, '{__value__} is not 5')
+        return value
+
+
+class EnsureInt(Constraint):
+    input_synopsis = 'must be convertible to type INT'
+    input_description = 'long-form of saying: it must be convertible to type INT'
+
+    def __call__(self, value):
+        try:
+            return int(value)
+        except ValueError as e:
+            self.raise_for(
+                value,
+                '{__value__} is not convertible to INT',
+                __caused_by__=e,
+            )
+
+
+def test_constraint_basics():
+    c = IsTrue()
+    assert str(c) == f'Constraint[{IsTrue.input_synopsis}]'
+    assert repr(c) == f'{c.__class__.__name__}()'
+    assert c(True) is True
+    with pytest.raises(ConstraintError, match='False is not True') as e:
+        c(False)
+    # first value is the exception
+    assert e.value.value is False
+
+
+def test_constraint_anyof():
+    # logical OR
+    c = IsTrue()
+    eq5 = Equals5()
+    true_or_5 = c | eq5
+    assert str(true_or_5) == f'Constraint[{c.input_synopsis} or {eq5.input_synopsis}]'
+    assert repr(true_or_5) == f'{true_or_5.__class__.__name__}({c!r}, {eq5!r})'
+    assert true_or_5(True) is True
+    assert true_or_5(5) == 5  # noqa: PLR2004
+    assert true_or_5(5.0) == 5.0  # noqa: PLR2004
+    with pytest.raises(ConstraintError, match='False is not True'):
+        true_or_5(False)
+    with pytest.raises(ConstraintError, match='not match any of 2'):
+        true_or_5('five')
+
+    # we can chain AnyOf, and we get no nesting
+    true_or_5_or_int = true_or_5 | EnsureInt()
+    assert len(true_or_5_or_int.constraints) == len(true_or_5.constraints) + 1
+    # also works with AnyOf and AnyOf
+    monster = true_or_5 | true_or_5_or_int
+    # it just merges the lists, this is inelegant but still correct
+    assert len(monster.constraints) == len(true_or_5.constraints) + len(
+        true_or_5_or_int.constraints
+    )
+
+    # somehow both descriptions are in there. we do not test further, because
+    # the current implementation is not sufficient anyways
+    assert c.input_description in true_or_5.input_description
+    assert eq5.input_description in true_or_5.input_description
+
+
+def test_constraint_allof():
+    # logical AND
+    int5 = EnsureInt() & Equals5()
+    assert isinstance(int5('5'), int)
+    assert int5('5') == 5  # noqa: PLR2004
+    with pytest.raises(ConstraintError, match='five is not convertible to INT'):
+        int5('five')
+
+    # test corner of of an AllOf of a single one
+    eq5 = Equals5()
+    aoeq5 = AllOf(eq5)
+    assert str(aoeq5) == str(eq5)
+
+    # check merge rules work out, chaining, not nesting
+    assert len((aoeq5 & eq5).constraints) == len(aoeq5.constraints) + 1
+    assert len((aoeq5 & int5).constraints) == len(aoeq5.constraints) + len(
+        int5.constraints
+    )
+
+    # somehow both descriptions are in there. we do not test further, because
+    # the current implementation is not sufficient anyways
+    assert EnsureInt().input_description in int5.input_description
+    assert eq5.input_description in int5.input_description

--- a/datalad_core/constraints/tests/test_exceptions.py
+++ b/datalad_core/constraints/tests/test_exceptions.py
@@ -1,0 +1,52 @@
+from datalad_core.constraints.exceptions import ConstraintError
+
+fake_constraint = None
+value_placeholder = 'noint'
+msg_placefolder = 'yeah, {__value__!r} is stupid. Why?\n{__itemized_causes__}'
+msg_placefolder_nocause = 'yeah, {__value__!r} is stupid'
+cause_placeholder = RuntimeError('too went south quickly')
+ctx_placeholder = {'__caused_by__': cause_placeholder}
+error_init_args = (fake_constraint, value_placeholder, msg_placefolder, ctx_placeholder)
+error_init_args_noctx = (fake_constraint, value_placeholder, msg_placefolder_nocause)
+
+
+def test_constrainterror():
+    ce = ConstraintError(*error_init_args)
+    assert ce.constraint is fake_constraint
+
+
+def test_constrainterror_repr():
+    ce = ConstraintError(*error_init_args)
+    assert repr(ce) == (
+        f'ConstraintError({fake_constraint!r}, {value_placeholder!r}, '
+        f'{msg_placefolder!r}, {ctx_placeholder!r})'
+    )
+    assert (
+        ce.msg
+        == str(ce)
+        == msg_placefolder.format(
+            __value__=value_placeholder, __itemized_causes__=f'  - {cause_placeholder}'
+        )
+    )
+
+
+def test_constrainterror_repr_noctx():
+    ce = ConstraintError(*error_init_args_noctx)
+    assert (
+        ce.msg == str(ce) == msg_placefolder_nocause.format(__value__=value_placeholder)
+    )
+
+
+def test_constrainterror_repr_multiexception():
+    ce = ConstraintError(
+        *error_init_args[:-1],
+        {'__caused_by__': (cause_placeholder, RuntimeError('even more cause'))},
+    )
+    assert (
+        ce.msg
+        == str(ce)
+        == msg_placefolder.format(
+            __value__=value_placeholder,
+            __itemized_causes__=(f'  - {cause_placeholder}\n' f'  - even more cause'),
+        )
+    )

--- a/datalad_core/constraints/tests/test_wrapper.py
+++ b/datalad_core/constraints/tests/test_wrapper.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ..constraint import Constraint
+from ..exceptions import ConstraintError
+from ..wrapper import WithDescription
+
+
+class IsTrue(Constraint):
+    input_synopsis = 'must be `True`'
+    input_description = 'long-form of saying: it must be `True`'
+
+    def __call__(self, value):
+        if value is not True:
+            self.raise_for(value, '{__value__} is not True')
+        return True
+
+
+def test_withdescription():
+    c = IsTrue()
+    # it is possible, albeit pointless, to not replace any description
+    d = WithDescription(c)
+    assert str(d) == str(c)
+
+    input_synopsis = 'must be True in this empire'
+    input_description = "bISeH'eghlaH'be'chugh latlh Dara'laH'be'"
+    error_message = '{__value__!r} has no honor'
+
+    d = WithDescription(
+        c,
+        input_synopsis=input_synopsis,
+        input_description=input_description,
+        error_message=error_message,
+    )
+    assert repr(d) == (
+        f'WithDescription({c!r}, '
+        f'input_synopsis={input_synopsis!r}, '
+        f'input_description={input_description!r}, '
+        # "input_synopsis_for_ds='dssynopsis', "
+        # "input_description_for_ds='dsdescription', "
+        f'error_message={error_message!r}'
+        # "error_message_for_ds='dserror')"
+        ')'
+    )
+
+    assert d.input_description == input_description
+
+    # the wrapped constraint looks like and unwrapped one
+    assert str(d) == f'Constraint[{input_synopsis}]'
+    with pytest.raises(ConstraintError) as e:
+        d(5)
+    assert e.value.msg == error_message.format(__value__=5)
+    assert d(True) is True

--- a/datalad_core/constraints/wrapper.py
+++ b/datalad_core/constraints/wrapper.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any
+
+from datalad_core.constraints.constraint import Constraint
+from datalad_core.constraints.exceptions import ConstraintError
+
+
+class WithDescription(Constraint):
+    """Constraint that wraps another constraint and replaces its description
+
+    Whenever a constraint's self-description does not fit an application
+    context, it can be wrapped with this class. The given synopsis and
+    description of valid inputs replaces those of the wrapped constraint.
+    """
+
+    def __init__(
+        self,
+        constraint: Constraint,
+        *,
+        input_synopsis: str | None = None,
+        input_description: str | None = None,
+        error_message: str | None = None,
+        # input_synopsis_for_ds: str | None = None,
+        # input_description_for_ds: str | None = None,
+        # error_message_for_ds: str | None = None,
+    ):
+        """
+        ``constraint`` can be any :class:`Constraint` subclass instance, and
+        it will be used to perform the actual processing.
+
+        If any of ``input_synopsis`` or ``input_description`` are given, they
+        replace the respective property of the wrapped ``constraint``.
+
+        If given, ``error_message`` replaces the error message of a
+        :class:`ConstraintError` raised by the wrapped ``Constraint``. Only the
+        message (template) is replaced, not the error context dictionary.
+        """
+        # input_synopsis_for_ds: optional
+        #   If either this, or ``input_description_for_ds``, or
+        #   ``error_message_for_ds`` are given, the result of tailoring a
+        #   constraint for a particular dataset (``for_dataset()``) will
+        #   also be wrapped with this custom synopsis.
+        # input_description_for_ds: optional
+        #   If either this, or ``input_synopsis_for_ds``, or
+        #   ``error_message_for_ds`` are given, the result of tailoring a
+        #   constraint for a particular dataset (``for_dataset()``) will
+        #   also be wrapped with this custom description.
+        # error_message: optional
+        #   If either this, or ``input_synopsis_for_ds``, or
+        #   ``input_description_for_ds`` are given, the result of tailoring a
+        #   constraint for a particular dataset (``for_dataset()``) will
+        #   also be wrapped with this custom error message (template).
+        super().__init__()
+        self._constraint = constraint
+        self._synopsis = input_synopsis
+        self._description = input_description
+        self._error_message = error_message
+        # self._synopsis_for_ds = input_synopsis_for_ds
+        # self._description_for_ds = input_description_for_ds
+        # self._error_message_for_ds = error_message_for_ds
+
+    @property
+    def constraint(self) -> Constraint:
+        """Returns the wrapped constraint instance"""
+        return self._constraint
+
+    def __call__(self, value: Any) -> Any:
+        try:
+            return self._constraint(value)
+        except ConstraintError as e:
+            # rewrap the error to get access to the top-level
+            # self-description.
+            msg, cnstr, value, ctx = e.args
+            raise ConstraintError(
+                self,
+                value,
+                self._error_message or msg,
+                ctx,
+            ) from e
+
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}'
+            f'({self._constraint!r}, '
+            f'input_synopsis={self._synopsis!r}, '
+            f'input_description={self._description!r}, '
+            # f'input_synopsis_for_ds={self._synopsis_for_ds!r}, '
+            # f'input_description_for_ds={self._description_for_ds!r}, '
+            f'error_message={self._error_message!r}'
+            # f'error_message_for_ds={self._error_message_for_ds!r})'
+            ')'
+        )
+
+    # def for_dataset(self, dataset: DatasetParameter) -> Constraint:
+    #    """Wrap the wrapped constraint again after tailoring it for the dataset
+    #    """
+    #    if any(x is not None for x in (
+    #            self._synopsis_for_ds,
+    #            self._description_for_ds,
+    #            self._error_message_for_ds)):
+    #        # we also want to wrap the tailored constraint
+    #        return self.__class__(
+    #            self._constraint.for_dataset(dataset),
+    #            input_synopsis=self._synopsis_for_ds,
+    #            input_description=self._description_for_ds,
+    #            error_message=self._error_message_for_ds,
+    #        )
+    #    else:
+    #        return self._constraint.for_dataset(dataset)
+
+    @property
+    def input_synopsis(self) -> str:
+        return self._synopsis or self.constraint.input_synopsis
+
+    @property
+    def input_description(self) -> str:
+        return self._description or self.constraint.input_description

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Also see the :ref:`modindex`.
    :toctree: generated
 
    config
+   constraints
    consts
    repo
    runners


### PR DESCRIPTION
The purpose of this class is to avoid validation code communicating causes and context information in text-form (only).

Instead, exceptions can carry the constraint that was violated (instance), the value that caused the violation, a message (with placeholders) on the nature of the violation, and any number of context items (used to format a full error message).

Importantly, this context supports a dedicated `__caused_by__` item, which can carry any number of underlying exceptions that lead to the validation error. This supports "exhaustive" validation, i.e. a validation that need not stop on the first detected issue. Instead, all issues can be communicated at once.